### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/file-upload-action/security/code-scanning/1](https://github.com/qbee-io/file-upload-action/security/code-scanning/1)

To fix this problem, explicitly declare the workflow's permissions by adding a `permissions:` block, either at the root (top-level, applying to all jobs) or directly under the job definition for `build`. The least privileged setting—and the one recommended by CodeQL as a minimal starting point—is `permissions: contents: read`. This setting allows the workflow to read repository contents but not make any changes. This fix should be made by inserting the following lines after the `name:` block and before `on:` (for global scope), or directly under the job (for single-job workflows like this).

The single best way to apply the fix, minimizing code changes and risk of breakage, is to add at the root level:
```yaml
permissions:
  contents: read
```
This should be inserted right after line 1.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
